### PR TITLE
Allow newer nokogiri versions

### DIFF
--- a/mobiledoc-html-renderer.gemspec
+++ b/mobiledoc-html-renderer.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 
-  spec.add_dependency "nokogiri", "~> 1.6.2"
+  spec.add_dependency "nokogiri", "~> 1.6"
 end


### PR DESCRIPTION
At the moment the nokogiri dependency is quite restrictive, this change allows using nokogiri up to (but not including) 2.x. I feel like nokogiri has been good at following semver over the years, but this can be more conservative with something like `">= 1.6.0", "< 1.9.0"` if needed.

@elucid 👋I was actually looking into implementing a ruby Mobiledoc renderer when I stumbled onto your gem. You did a great job with it, but looks like lately there has not been much activity on the repo. I'm wondering if you're looking for any help with maintaining the gem (addressing opened issues, releasing to rubygems, etc.)?

We're currently experimenting with Mobiledoc for a new version of our editor and if we end up using it I'll have some dev cycles to spend on the ruby rendered.