### PR TITLE
Add support for Mobiledoc 0.3.1

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -6,7 +6,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_2
-    MOBILEDOC_VERSION = '0.2.0'
+    MOBILEDOC_VERSIONS = ['0.2.0']
 
     include Mobiledoc::Utils::SectionTypes
     include Mobiledoc::Utils::TagNames
@@ -27,8 +27,8 @@ module Mobiledoc
     end
 
     def validate_version(version)
-      if version != self.class::MOBILEDOC_VERSION
-        raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"]);
+      unless self.class::MOBILEDOC_VERSIONS.to_a.include? version
+        raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])
       end
     end
 

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -4,7 +4,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_3 < Renderer_0_2
-    MOBILEDOC_VERSION = '0.3.0'
+    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1']
 
     include Mobiledoc::Utils::MarkerTypes
 

--- a/lib/mobiledoc/utils/tag_names.rb
+++ b/lib/mobiledoc/utils/tag_names.rb
@@ -2,7 +2,7 @@ module Mobiledoc
   module Utils
     module TagNames
       MARKUP_SECTION_TAG_NAMES = [
-        'p', 'h1', 'h2', 'h3', 'blockquote', 'pull-quote'
+        'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pull-quote', 'aside'
       ]
 
       LIST_SECTION_TAG_NAMES = [
@@ -10,7 +10,7 @@ module Mobiledoc
       ]
 
       MARKUP_TYPES = [
-        'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's'
+        'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's', 'code'
       ]
 
       def normalize_tag_name(name)

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -66,9 +66,9 @@ module Mobiledoc
       version = mobiledoc['version']
 
       case version
-      when '0.2.0', nil
+      when '0.2.0'
         Renderer_0_2.new(mobiledoc, state).render
-      when '0.3.0', nil
+      when '0.3.0', '0.3.1', nil
         Renderer_0_3.new(mobiledoc, state).render
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -729,5 +729,27 @@ module ZeroThreeZero
       renderer = Mobiledoc::HTMLRenderer.new(atoms: [], card_options: expected_options, unknown_atom_handler: unknown_atom_handler)
       rendered = renderer.render(mobiledoc)
     end
+
+    context '0.3.1' do
+      it 'renders 0.3.1-specific sections and markups' do
+        mobiledoc = {
+          'version' => '0.3.1',
+          'atoms' => [],
+          'cards' => [],
+          'markups' => [
+            ['CODE']
+          ],
+          'sections' => [
+            [MARKUP_SECTION_TYPE, 'ASIDE', [
+              [MARKUP_MARKER_TYPE, [0], 1, 'hello world']]
+            ]
+          ]
+        }
+
+        rendered = render(mobiledoc)
+
+        expect(rendered).to eq('<div><aside><code>hello world</code></aside></div>')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is more conservative then https://github.com/elucid/mobiledoc-html-renderer/pull/12 in terms of versioning and also adds new 0.3.1-specific tags.

Relevant change in Mobiledoc: https://github.com/bustle/mobiledoc-kit/commit/57670bb9279b0a98084ccab2fe308cd2b6fa1e7b#diff-fc12a9e0cdab7e014ce2d37c64fc5b5c