### PR TITLE
Add section & markup element renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ renderer = Mobiledoc::HTMLRenderer.new(cards: [TitleCard], atoms: [MentionAtom])
 renderer.render(mobiledoc) # "<div><h1 class='title'>Oh hai</h1><span class='mention'>@sdhull</span></div>"
 ```
 
+### Custom Element Renderers
+
+As with the javascript renderer, you can define custom element renderers. Unlike the javascript renderer, you can even define renderers for markups (not just sections). So for example, if you render strong tags in some special way, you might do it like this:
+
+```ruby
+# == Parameters:
+# create_element::
+#   A proc that accepts a tagname and will return a Nokogiri node.
+#
+# attributes::
+#   Hash of attributes that were stored with that markup (only passed to markup renderers, not to section renderers).
+#
+# == Returns:
+# MUST return the node created by `create_element`
+#
+strong_renderer = lambda do |create_element, attributes|
+  element = create_element.call('strong')
+  weight = attributes['data-weight']
+  element.set_attribute('class', "font-weight-#{weight}")
+  element
+end
+renderer = Mobiledoc::HTMLRenderer.new(element_renderer: {'STRONG' => strong_renderer})
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,81 @@ mobiledoc = {
 renderer = Mobiledoc::HTMLRenderer.new(cards: [])
 renderer.render(mobiledoc) # "<div><p><b>hello world</b></p></div>"
 ```
+### Cards & Atoms
+
+Define an object that responds to `#name`, `#type` and `#render`. Examples use a module but you can use whatever you like.
+The `#render` method signatures is the only difference between cards & atoms.
+
+```ruby
+module TitleCard
+  module_function
+
+  # must match card name in mobiledoc document
+  def name
+    'title'
+  end
+
+  # must be 'html'
+  def type
+    'html'
+  end
+
+  # == Parameters:
+  # env::
+  #   A hash containing the key `:name` that will be equal to the name of the card/atom
+  #
+  # payload::
+  #   The payload that was stored with this card/atom
+  #
+  # options::
+  #   Options passed to the renderer at render time as `card_options`
+  #
+  # == Returns:
+  # A string representing the card
+  #
+  def render(env, payload, options)
+    "<h1 class='title'>#{payload['content']}</h1>"
+  end
+end
+
+module MentionAtom
+  module_function
+
+  # must match atom name in mobiledoc document
+  def name
+    'mention'
+  end
+
+  # must be 'html'
+  def type
+    'html'
+  end
+
+  # == Parameters:
+  # env::
+  #   A hash containing the key `:name` that will be equal to the name of the atom
+  #
+  # value::
+  #   The value that was stored with the atom
+  #
+  # payload::
+  #   The payload that was stored with this atom
+  #
+  # options::
+  #   Options passed to the renderer at render time as `card_options`
+  #
+  # == Returns:
+  # A string representing the atom
+  #
+  def render(env, value, payload, options)
+    "<span class='mention'>#{value}</span>"
+  end
+end
+
+mobiledoc = ...
+renderer = Mobiledoc::HTMLRenderer.new(cards: [TitleCard], atoms: [MentionAtom])
+renderer.render(mobiledoc) # "<div><h1 class='title'>Oh hai</h1><span class='mention'>@sdhull</span></div>"
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,29 @@ renderer.render(mobiledoc) # "<div><h1 class='title'>Oh hai</h1><span class='men
 
 ### Custom Element Renderers
 
-As with the javascript renderer, you can define custom element renderers. Unlike the javascript renderer, you can even define renderers for markups (not just sections). So for example, if you render strong tags in some special way, you might do it like this:
+As with the javascript dom renderer, you can define custom element renderers. In order to maintain symmetry with the js dom renderer, these are passed as two hashes, `section_element_renderer` and `markup_element_renderer`. Note that keys in these hashes must be uppercase.
+
+#### section_element_renderer
+If you render h1 tags in some special way, you might do it like this:
+
+```ruby
+# == Parameters:
+# create_element::
+#   A proc that accepts a tagname and will return a Nokogiri node.
+#
+# == Returns:
+# MUST return the node created by `create_element`
+#
+h1_renderer = lambda do |create_element|
+  element = create_element.call('h1')
+  element.set_attribute('class', 'primary-title')
+  element
+end
+renderer = Mobiledoc::HTMLRenderer.new(section_element_renderer: {'H1' => h1_renderer})
+```
+
+#### markup_element_renderer
+For example, if you render strong tags in some special way, you might do it like this:
 
 ```ruby
 # == Parameters:
@@ -135,7 +157,7 @@ As with the javascript renderer, you can define custom element renderers. Unlike
 #   A proc that accepts a tagname and will return a Nokogiri node.
 #
 # attributes::
-#   Hash of attributes that were stored with that markup (only passed to markup renderers, not to section renderers).
+#   Hash of attributes that were stored with that markup.
 #
 # == Returns:
 # MUST return the node created by `create_element`
@@ -146,9 +168,8 @@ strong_renderer = lambda do |create_element, attributes|
   element.set_attribute('class', "font-weight-#{weight}")
   element
 end
-renderer = Mobiledoc::HTMLRenderer.new(element_renderer: {'STRONG' => strong_renderer})
+renderer = Mobiledoc::HTMLRenderer.new(markup_element_renderer: {'STRONG' => strong_renderer})
 ```
-
 
 ## Development
 

--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -11,7 +11,7 @@ module Mobiledoc
     include Mobiledoc::Utils::SectionTypes
     include Mobiledoc::Utils::TagNames
 
-    attr_accessor :root, :marker_types, :sections, :doc, :cards, :card_options, :unknown_card_handler, :element_renderer
+    attr_accessor :root, :marker_types, :sections, :doc, :cards, :card_options, :unknown_card_handler, :markup_element_renderer, :section_element_renderer
 
     def initialize(mobiledoc, state)
       version, section_data = *mobiledoc.values_at('version', 'sections')
@@ -24,7 +24,8 @@ module Mobiledoc
       self.cards = state[:cards]
       self.card_options = state[:card_options]
       self.unknown_card_handler = state[:unknown_card_handler]
-      self.element_renderer = state[:element_renderer]
+      self.markup_element_renderer = state[:markup_element_renderer]
+      self.section_element_renderer = state[:section_element_renderer]
     end
 
     def validate_version(version)
@@ -65,7 +66,7 @@ module Mobiledoc
     end
 
     def create_element_from_marker_type(tag_name='', attributes=[])
-      custom_renderer = element_renderer[tag_name.upcase]
+      custom_renderer = markup_element_renderer[tag_name.upcase]
       return custom_renderer.call(method(:create_element), Hash[*attributes]) if custom_renderer
 
       element = create_element(tag_name)
@@ -98,7 +99,7 @@ module Mobiledoc
     def render_markup_section(type, tag_name, markers)
       return unless valid_section_tag_name?(tag_name, MARKUP_SECTION_TYPE)
 
-      custom_renderer = element_renderer[tag_name.upcase]
+      custom_renderer = section_element_renderer[tag_name.upcase]
       element = if custom_renderer
                   custom_renderer.call(method(:create_element))
                 else

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -8,7 +8,7 @@ module Mobiledoc
 
     include Mobiledoc::Utils::MarkerTypes
 
-    attr_accessor :atom_types, :card_types, :atoms, :unknown_atom_handler
+    attr_accessor :atom_types, :card_types, :atoms, :unknown_atom_handler, :element_renderer
 
     def initialize(mobiledoc, state)
       version, sections, atom_types, card_types, marker_types = *mobiledoc.values_at('version', 'sections', 'atoms', 'cards', 'markups')
@@ -25,6 +25,7 @@ module Mobiledoc
       self.card_options = state[:card_options]
       self.unknown_card_handler = state[:unknown_card_handler]
       self.unknown_atom_handler = state[:unknown_atom_handler]
+      self.element_renderer = state[:element_renderer]
     end
 
     def render_card_section(type, index)

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -8,7 +8,7 @@ module Mobiledoc
 
     include Mobiledoc::Utils::MarkerTypes
 
-    attr_accessor :atom_types, :card_types, :atoms, :unknown_atom_handler, :element_renderer
+    attr_accessor :atom_types, :card_types, :atoms, :unknown_atom_handler
 
     def initialize(mobiledoc, state)
       version, sections, atom_types, card_types, marker_types = *mobiledoc.values_at('version', 'sections', 'atoms', 'cards', 'markups')
@@ -25,7 +25,8 @@ module Mobiledoc
       self.card_options = state[:card_options]
       self.unknown_card_handler = state[:unknown_card_handler]
       self.unknown_atom_handler = state[:unknown_atom_handler]
-      self.element_renderer = state[:element_renderer]
+      self.markup_element_renderer = state[:markup_element_renderer]
+      self.section_element_renderer = state[:section_element_renderer]
     end
 
     def render_card_section(type, index)

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -17,6 +17,7 @@ module Mobiledoc
       validate_atoms(atoms)
 
       card_options = options[:card_options] || {}
+      element_renderer = options[:element_renderer] || {}
 
       unknown_card_handler = options[:unknown_card_handler] || UnknownCard
       unknown_atom_handler = options[:unknown_atom_handler] || UnknownAtom
@@ -26,7 +27,8 @@ module Mobiledoc
         atoms: atoms,
         card_options: card_options,
         unknown_card_handler: unknown_card_handler,
-        unknown_atom_handler: unknown_atom_handler
+        unknown_atom_handler: unknown_atom_handler,
+        element_renderer: element_renderer,
       }
     end
 

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -17,7 +17,8 @@ module Mobiledoc
       validate_atoms(atoms)
 
       card_options = options[:card_options] || {}
-      element_renderer = options[:element_renderer] || {}
+      section_element_renderer = options[:section_element_renderer] || {}
+      markup_element_renderer = options[:markup_element_renderer] || {}
 
       unknown_card_handler = options[:unknown_card_handler] || UnknownCard
       unknown_atom_handler = options[:unknown_atom_handler] || UnknownAtom
@@ -28,7 +29,8 @@ module Mobiledoc
         card_options: card_options,
         unknown_card_handler: unknown_card_handler,
         unknown_atom_handler: unknown_atom_handler,
-        element_renderer: element_renderer,
+        section_element_renderer: section_element_renderer,
+        markup_element_renderer: markup_element_renderer,
       }
     end
 

--- a/spec/0.2_spec.rb
+++ b/spec/0.2_spec.rb
@@ -506,19 +506,17 @@ module ZeroTwoZero
       expect(rendered).to_not match(/script/)
     end
 
-    it 'supports passing a element_renderer' do
-      element_renderer = {
-        'STRONG' => lambda do |create_element, attributes|
-          element = create_element.call('strong')
-          element.set_attribute('style', "color: #{attributes['data-color']}")
-          element
-        end,
-        'H2' => lambda do |create_element|
-          element = create_element.call('div')
-          element.set_attribute('class', 'subheadline')
-          element
-        end
-      }
+    it 'supports passing custom element renderers' do
+      strong = lambda do |create_element, attributes|
+        element = create_element.call('strong')
+        element.set_attribute('style', "color: #{attributes['data-color']}")
+        element
+      end
+      h2 = lambda do |create_element|
+        element = create_element.call('div')
+        element.set_attribute('class', 'subheadline')
+        element
+      end
       mobiledoc = {
         'version' => MOBILEDOC_VERSION,
         'sections' => [
@@ -534,7 +532,7 @@ module ZeroTwoZero
         ]
       }
 
-      renderer = Mobiledoc::HTMLRenderer.new(cards: [], element_renderer: element_renderer)
+      renderer = Mobiledoc::HTMLRenderer.new(cards: [], section_element_renderer: {'H2' => h2}, markup_element_renderer: {'STRONG' => strong})
       rendered = renderer.render(mobiledoc)
 
       expect(rendered).to eq('<div><div class="subheadline">plain h2 <strong style="color: blue">blue strong bit</strong></div></div>')

--- a/spec/0.2_spec.rb
+++ b/spec/0.2_spec.rb
@@ -505,5 +505,39 @@ module ZeroTwoZero
 
       expect(rendered).to_not match(/script/)
     end
+
+    it 'supports passing a element_renderer' do
+      element_renderer = {
+        'STRONG' => lambda do |create_element, attributes|
+          element = create_element.call('strong')
+          element.set_attribute('style', "color: #{attributes['data-color']}")
+          element
+        end,
+        'H2' => lambda do |create_element|
+          element = create_element.call('div')
+          element.set_attribute('class', 'subheadline')
+          element
+        end
+      }
+      mobiledoc = {
+        'version' => MOBILEDOC_VERSION,
+        'sections' => [
+          [
+            ['strong', ['data-color', 'blue']]
+          ], # MARKUPS
+          [
+            [MARKUP_SECTION_TYPE, 'h2', [
+              [[], 0, 'plain h2 '],
+              [[0], 1, 'blue strong bit'],
+            ]],
+          ]
+        ]
+      }
+
+      renderer = Mobiledoc::HTMLRenderer.new(cards: [], element_renderer: element_renderer)
+      rendered = renderer.render(mobiledoc)
+
+      expect(rendered).to eq('<div><div class="subheadline">plain h2 <strong style="color: blue">blue strong bit</strong></div></div>')
+    end
   end
 end

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -731,18 +731,16 @@ module ZeroThreeZero
     end
 
     it 'supports passing a element_renderer' do
-      element_renderer = {
-        'STRONG' => lambda do |create_element, attributes|
-          element = create_element.call('strong')
-          element.set_attribute('style', "color: #{attributes['data-color']}")
-          element
-        end,
-        'H2' => lambda do |create_element|
-          element = create_element.call('div')
-          element.set_attribute('class', 'subheadline')
-          element
-        end
-      }
+      strong = lambda do |create_element, attributes|
+        element = create_element.call('strong')
+        element.set_attribute('style', "color: #{attributes['data-color']}")
+        element
+      end
+      h2 = lambda do |create_element|
+        element = create_element.call('div')
+        element.set_attribute('class', 'subheadline')
+        element
+      end
       mobiledoc = {
         'version' => MOBILEDOC_VERSION,
         'atoms' => [],
@@ -758,7 +756,7 @@ module ZeroThreeZero
         ]
       }
 
-      renderer = Mobiledoc::HTMLRenderer.new(cards: [], element_renderer: element_renderer)
+      renderer = Mobiledoc::HTMLRenderer.new(cards: [], section_element_renderer: {'H2' => h2}, markup_element_renderer: {'STRONG' => strong})
       rendered = renderer.render(mobiledoc)
 
       expect(rendered).to eq('<div><div class="subheadline">plain h2 <strong style="color: blue">blue strong bit</strong></div></div>')

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -729,5 +729,39 @@ module ZeroThreeZero
       renderer = Mobiledoc::HTMLRenderer.new(atoms: [], card_options: expected_options, unknown_atom_handler: unknown_atom_handler)
       rendered = renderer.render(mobiledoc)
     end
+
+    it 'supports passing a element_renderer' do
+      element_renderer = {
+        'STRONG' => lambda do |create_element, attributes|
+          element = create_element.call('strong')
+          element.set_attribute('style', "color: #{attributes['data-color']}")
+          element
+        end,
+        'H2' => lambda do |create_element|
+          element = create_element.call('div')
+          element.set_attribute('class', 'subheadline')
+          element
+        end
+      }
+      mobiledoc = {
+        'version' => MOBILEDOC_VERSION,
+        'atoms' => [],
+        'cards' => [],
+        'markups' => [
+          ['strong', ['data-color', 'blue']]
+        ],
+        'sections' => [
+          [MARKUP_SECTION_TYPE, 'h2', [
+            [MARKUP_MARKER_TYPE, [], 0, 'plain h2 '],
+            [MARKUP_MARKER_TYPE, [0], 1, 'blue strong bit'],
+          ]],
+        ]
+      }
+
+      renderer = Mobiledoc::HTMLRenderer.new(cards: [], element_renderer: element_renderer)
+      rendered = renderer.render(mobiledoc)
+
+      expect(rendered).to eq('<div><div class="subheadline">plain h2 <strong style="color: blue">blue strong bit</strong></div></div>')
+    end
   end
 end


### PR DESCRIPTION
The javascript dom renderer includes support for passing [`sectionElementRenderer`](https://github.com/bustle/mobiledoc-dom-renderer#sectionelementrenderer) & `markupElementRenderer` hashes to the renderer in order to allow developers to customize how elements are rendered.

We have a need to customize how various markups are rendered so this adds `section_element_renderer` & `markup_element_renderer` as options to `Mobiledoc::HTMLRenderer.new` such that both markup & section elements can be customized.

As a bonus, it also adds documentation about how to specify atoms & cards.