### PR TITLE
Add support for mobiledoc 0.3.2

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -6,7 +6,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_2
-    MOBILEDOC_VERSION = '0.2.0'
+    MOBILEDOC_VERSIONS = ['0.2.0']
 
     include Mobiledoc::Utils::SectionTypes
     include Mobiledoc::Utils::TagNames
@@ -27,8 +27,8 @@ module Mobiledoc
     end
 
     def validate_version(version)
-      if version != self.class::MOBILEDOC_VERSION
-        raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"]);
+      unless self.class::MOBILEDOC_VERSIONS.to_a.include? version
+        raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])
       end
     end
 

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -4,7 +4,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_3 < Renderer_0_2
-    MOBILEDOC_VERSION = '0.3.0'
+    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1']
 
     include Mobiledoc::Utils::MarkerTypes
 

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -4,7 +4,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_3 < Renderer_0_2
-    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1']
+    MOBILEDOC_VERSIONS = ['0.3.0', '0.3.1', '0.3.2']
 
     include Mobiledoc::Utils::MarkerTypes
 
@@ -25,6 +25,17 @@ module Mobiledoc
       self.card_options = state[:card_options]
       self.unknown_card_handler = state[:unknown_card_handler]
       self.unknown_atom_handler = state[:unknown_atom_handler]
+    end
+
+    def render_markup_section(type, tag_name, markers, attributes = [])
+      return unless valid_section_tag_name?(tag_name, MARKUP_SECTION_TYPE)
+
+      element = create_element(tag_name)
+      attributes.each_slice(2) do |prop_name, prop_value|
+        set_attribute(element, prop_name, prop_value)
+      end
+      _render_markers_on_element(element, markers)
+      element
     end
 
     def render_card_section(type, index)

--- a/lib/mobiledoc/utils/tag_names.rb
+++ b/lib/mobiledoc/utils/tag_names.rb
@@ -2,7 +2,7 @@ module Mobiledoc
   module Utils
     module TagNames
       MARKUP_SECTION_TAG_NAMES = [
-        'p', 'h1', 'h2', 'h3', 'blockquote', 'pull-quote'
+        'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pull-quote', 'aside'
       ]
 
       LIST_SECTION_TAG_NAMES = [
@@ -10,7 +10,7 @@ module Mobiledoc
       ]
 
       MARKUP_TYPES = [
-        'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's'
+        'b', 'i', 'strong', 'em', 'a', 'u', 'sub', 'sup', 's', 'code'
       ]
 
       def normalize_tag_name(name)

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -66,9 +66,9 @@ module Mobiledoc
       version = mobiledoc['version']
 
       case version
-      when '0.2.0', nil
+      when '0.2.0'
         Renderer_0_2.new(mobiledoc, state).render
-      when '0.3.0', nil
+      when '0.3.0', '0.3.1', nil
         Renderer_0_3.new(mobiledoc, state).render
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -68,7 +68,7 @@ module Mobiledoc
       case version
       when '0.2.0'
         Renderer_0_2.new(mobiledoc, state).render
-      when '0.3.0', '0.3.1', nil
+      when '0.3.0', '0.3.1', '0.3.2', nil
         Renderer_0_3.new(mobiledoc, state).render
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -729,5 +729,27 @@ module ZeroThreeZero
       renderer = Mobiledoc::HTMLRenderer.new(atoms: [], card_options: expected_options, unknown_atom_handler: unknown_atom_handler)
       rendered = renderer.render(mobiledoc)
     end
+
+    context '0.3.1' do
+      it 'renders 0.3.1-specific sections and markups' do
+        mobiledoc = {
+          'version' => '0.3.1',
+          'atoms' => [],
+          'cards' => [],
+          'markups' => [
+            ['CODE']
+          ],
+          'sections' => [
+            [MARKUP_SECTION_TYPE, 'ASIDE', [
+              [MARKUP_MARKER_TYPE, [0], 1, 'hello world']]
+            ]
+          ]
+        }
+
+        rendered = render(mobiledoc)
+
+        expect(rendered).to eq('<div><aside><code>hello world</code></aside></div>')
+      end
+    end
   end
 end

--- a/spec/0.3_spec.rb
+++ b/spec/0.3_spec.rb
@@ -751,5 +751,32 @@ module ZeroThreeZero
         expect(rendered).to eq('<div><aside><code>hello world</code></aside></div>')
       end
     end
+
+    context '0.3.2' do
+      it 'renders 0.3.2-specific sections with attributes' do
+        mobiledoc = {
+          'version' => '0.3.2',
+          'atoms' => [],
+          'cards' => [],
+          'markups' => [
+            ['CODE']
+          ],
+          'sections' => [
+            [
+              MARKUP_SECTION_TYPE,
+              'ASIDE',
+              [
+                [MARKUP_MARKER_TYPE, [0], 1, 'hello world']
+              ],
+              ["data-md-text-align", "center"]
+            ]
+          ]
+        }
+
+        rendered = render(mobiledoc)
+
+        expect(rendered).to eq('<div><aside data-md-text-align="center"><code>hello world</code></aside></div>')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR builds on https://github.com/elucid/mobiledoc-html-renderer/pull/14 to add support for mobiledoc 0.3.2

Relevant change in mobiledoc spec: https://github.com/bustle/mobiledoc-kit/commit/0449e15efc48621137fb61f71eff2c6e1d0ddfaf